### PR TITLE
fix(csi-node): Fix metrics bind address in case of shared network

### DIFF
--- a/deploy/jiva-csi-ubuntu-16.04.yaml
+++ b/deploy/jiva-csi-ubuntu-16.04.yaml
@@ -281,6 +281,11 @@ spec:
             # This count has been set to 30 for sanity test cases as it takes
             # time in minikube
             - "--retrycount=30"
+            # metricsBindAddress is the TCP address that the controller should bind to
+            # for serving prometheus metrics. By default the address is set to localhost:9505.
+            # The address can be configured to any desired address.
+            # Remove the flag to disable prometheus metrics.
+            - "--metricsBindAddress=:9505"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -284,13 +284,13 @@ spec:
             # metricsBindAddress is the TCP address that the controller should bind to
             # for serving prometheus metrics. Change the port if 9505 is already in use.
             # Remove the flag to disable prometheus metrics.
-            - "--metricsBindAddress=$(METRICS_BIND_ADDRESS):9505"
+            - "--metricsBindAddress=$(OPENEBS_POD_IP):9505"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: METRICS_BIND_ADDRESS
+            - name: OPENEBS_POD_IP
               valueFrom:
                 fieldRef:
                   fieldPath: status.podIP

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -282,18 +282,15 @@ spec:
             # time in minikube
             - "--retrycount=10"
             # metricsBindAddress is the TCP address that the controller should bind to
-            # for serving prometheus metrics. Change the port if 9505 is already in use.
+            # for serving prometheus metrics. By default the address is set to localhost:9505.
+            # The address can be configured to any desired address.
             # Remove the flag to disable prometheus metrics.
-            - "--metricsBindAddress=$(OPENEBS_POD_IP):9505"
+            - "--metricsBindAddress=:9505"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
-            - name: OPENEBS_POD_IP
-              valueFrom:
-                fieldRef:
-                  fieldPath: status.podIP
             - name: OPENEBS_CSI_ENDPOINT
               value: unix:///plugin/csi.sock
             - name: OPENEBS_NODE_DRIVER

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -281,11 +281,19 @@ spec:
             # This count has been set to 10 for sanity test cases as it takes
             # time in minikube
             - "--retrycount=10"
+            # metricsBindAddress is the TCP address that the controller should bind to
+            # for serving prometheus metrics. Change the port if 9505 is already in use.
+            # Remove the flag to disable prometheus metrics.
+            - "--metricsBindAddress=$(METRICS_BIND_ADDRESS):9505"
           env:
             - name: OPENEBS_NODE_ID
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: METRICS_BIND_ADDRESS
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
             - name: OPENEBS_CSI_ENDPOINT
               value: unix:///plugin/csi.sock
             - name: OPENEBS_NODE_DRIVER

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -77,8 +77,8 @@ func (cl *Client) Set() error {
 
 // RegisterAPI registers the API scheme in the client using the manager.
 // This function needs to be called only once a client object
-func (cl *Client) RegisterAPI() error {
-	mgr, err := manager.New(cl.cfg, manager.Options{})
+func (cl *Client) RegisterAPI(opts manager.Options) error {
+	mgr, err := manager.New(cl.cfg, opts)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR changes the `MetricsBindAddress` which is by default set to `localhost:8080` to `podIP:9505` as in case of shared network(``hostNetwork: true``) `nodeIP` and `podIP` is the same for daemonset pods. The port on the address is also configurable to avoid any errors if the port is already in use. If the flag is removed from the yaml the default value `0` is set which will disable the prometheus metrics.