### PR TITLE
feat(jiva-csi): Add JivaVolumePolicy schema changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - make bootstrap
 
 before_install:
-  - git clone --branch=policy https://github.com/shubham14bajpai/jiva-operator $GOPATH/src/github.com/openebs/jiva-operator
+  - git clone https://www.github.com/openebs/jiva-operator $GOPATH/src/github.com/openebs/jiva-operator
   - sudo apt-get install -y open-iscsi
   - sudo service open-iscsi restart
   - sudo systemctl enable iscsid && sudo systemctl start iscsid

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - make bootstrap
 
 before_install:
-  - git clone https://www.github.com/openebs/jiva-operator $GOPATH/src/github.com/openebs/jiva-operator
+  - git clone --branch=policy https://github.com/shubham14bajpai/jiva-operator $GOPATH/src/github.com/openebs/jiva-operator
   - sudo apt-get install -y open-iscsi
   - sudo service open-iscsi restart
   - sudo systemctl enable iscsid && sudo systemctl start iscsid
@@ -48,7 +48,7 @@ script:
   - cd $GOPATH/src/github.com/openebs/jiva-operator
   - wget https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
   - kubectl apply -f openebs-operator.yaml
-  - kubectl apply -f deploy/
+  - kubectl apply -f deploy/operator.yaml
   - cd ${TRAVIS_BUILD_DIR}
   - kubectl apply -f deploy/jiva-csi.yaml
   - ./ci/ci.sh

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -11,7 +11,7 @@ function initializeTestEnv() {
 	cat <<EOT >> /tmp/parameters.json
 {
         "cas-type": "jiva",
-        "replicaCount": "1"
+        "policy": "example-jivavolumepolicy"
 }
 EOT
   sudo rm -rf /tmp/csi.sock
@@ -117,7 +117,20 @@ function startTestSuite() {
 	exit 0
 }
 
+function createJivaVolumePolicy() {
+	echo "================== Create Jiva Volume Policy ================="
+	cd $GOPATH/src/github.com/openebs/jiva-operator
+	kubectl apply -f deploy/crds/openebs.io_v1alpha1_jivavolumepolicy_cr.yaml
+	if [ $? -ne 0 ];
+	then
+		dumpAllLogs
+		exit 1
+	fi
+	exit 0
+}
+
 initializeTestEnv
 waitForAllComponentsToBeReady
+createJivaVolumePolicy
 initializeCSISanitySuite
 startTestSuite

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -113,7 +113,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: openebs-jiva-csi-plugin
-          image: openebs/jiva-csi:policy
+          image: openebs/jiva-csi:ci
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_JIVA_CSI_CONTROLLER

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -47,7 +47,7 @@ rules:
     resources: ["events"]
     verbs: ["list", "watch", "create", "update", "patch"]
   - apiGroups: ["*"]
-    resources: ["jivavolumes"]
+    resources: ["jivavolumes", "jivavolumepolicies"]
     verbs: ["*"]
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
@@ -113,7 +113,7 @@ spec:
             - name: socket-dir
               mountPath: /var/lib/csi/sockets/pluginproxy/
         - name: openebs-jiva-csi-plugin
-          image: openebs/jiva-csi:ci
+          image: openebs/jiva-csi:policy
           imagePullPolicy: IfNotPresent
           env:
             - name: OPENEBS_JIVA_CSI_CONTROLLER

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/container-storage-interface/spec v1.1.0
 	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20191120152119-1430b53a1741
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
-	github.com/openebs/jiva-operator v0.0.0-20200131090827-c3a0cf46717f
+	github.com/openebs/jiva-operator v0.0.0-20200205073212-3baa569d64f2
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
@@ -23,7 +23,6 @@ require (
 )
 
 replace (
-	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator v0.0.0-20200129140224-a3a1919cdf15
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 )
 
 replace (
-	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd
+	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator v0.0.0-20200122113505-4c5a9a073f36
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	golang.org/x/text v0.3.2 // indirect
 	google.golang.org/genproto v0.0.0-20181202183823-bd91e49a0898 // indirect
 	google.golang.org/grpc v1.21.0
-	k8s.io/api v0.0.0
 	k8s.io/apimachinery v0.0.0
 	k8s.io/client-go v11.0.0+incompatible
 	k8s.io/cloud-provider v0.0.0
@@ -24,7 +23,7 @@ require (
 )
 
 replace (
-	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator a3a1919cdf152e0653a547b084f831971a22fd1f
+	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator v0.0.0-20200129140224-a3a1919cdf15
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719

--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 )
 
 replace (
-	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator v0.0.0-20200122113505-4c5a9a073f36
+	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator a3a1919cdf152e0653a547b084f831971a22fd1f
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 )
 
 replace (
+	github.com/openebs/jiva-operator => github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,11 @@ github.com/opencontainers/image-spec v0.0.0-20170604055404-372ad780f634/go.mod h
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
+<<<<<<< HEAD
 github.com/openebs/jiva-operator v0.0.0-20200131090827-c3a0cf46717f h1:wMtfHXjmOPGR4rTq+j7y4A2kCCCJ8LYWDNsiuC6IU70=
 github.com/openebs/jiva-operator v0.0.0-20200131090827-c3a0cf46717f/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
+=======
+>>>>>>> addressed review comments
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=

--- a/go.sum
+++ b/go.sum
@@ -450,6 +450,8 @@ github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/seccomp/libseccomp-golang v0.0.0-20150813023252-1b506fc7c24e/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
+github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd h1:qJUi82v4QaFG2HHGDHpLn+/RUg4XKC0ivwywt2yKpK8=
+github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20151028001915-10ef21a441db/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sigma/go-inotify v0.0.0-20181102212354-c87b6cf5033d/go.mod h1:stlh9OsqBQSdwxTxX73mu41BBtRbIpZLQ7flcAoxAfo=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/go.sum
+++ b/go.sum
@@ -379,11 +379,8 @@ github.com/opencontainers/image-spec v0.0.0-20170604055404-372ad780f634/go.mod h
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-<<<<<<< HEAD
 github.com/openebs/jiva-operator v0.0.0-20200131090827-c3a0cf46717f h1:wMtfHXjmOPGR4rTq+j7y4A2kCCCJ8LYWDNsiuC6IU70=
 github.com/openebs/jiva-operator v0.0.0-20200131090827-c3a0cf46717f/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
-=======
->>>>>>> addressed review comments
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
@@ -455,6 +452,8 @@ github.com/seccomp/libseccomp-golang v0.0.0-20150813023252-1b506fc7c24e/go.mod h
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd h1:qJUi82v4QaFG2HHGDHpLn+/RUg4XKC0ivwywt2yKpK8=
 github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
+github.com/shubham14bajpai/jiva-operator v0.0.0-20200129140224-a3a1919cdf15 h1:f0juOmO+NlPawvT68naJ4QeJz3103KTjOEvwERrGloo=
+github.com/shubham14bajpai/jiva-operator v0.0.0-20200129140224-a3a1919cdf15/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20151028001915-10ef21a441db/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sigma/go-inotify v0.0.0-20181102212354-c87b6cf5033d/go.mod h1:stlh9OsqBQSdwxTxX73mu41BBtRbIpZLQ7flcAoxAfo=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,8 @@ github.com/opencontainers/image-spec v0.0.0-20170604055404-372ad780f634/go.mod h
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openebs/jiva-operator v0.0.0-20200131090827-c3a0cf46717f h1:wMtfHXjmOPGR4rTq+j7y4A2kCCCJ8LYWDNsiuC6IU70=
-github.com/openebs/jiva-operator v0.0.0-20200131090827-c3a0cf46717f/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
+github.com/openebs/jiva-operator v0.0.0-20200205073212-3baa569d64f2 h1:OE3HzKzKRdhiVdS42/3de6Ew9GGLL0MwPs9GYkO6nv0=
+github.com/openebs/jiva-operator v0.0.0-20200205073212-3baa569d64f2/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
@@ -450,10 +450,6 @@ github.com/sclevine/spec v1.0.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
 github.com/seccomp/libseccomp-golang v0.0.0-20150813023252-1b506fc7c24e/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
-github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd h1:qJUi82v4QaFG2HHGDHpLn+/RUg4XKC0ivwywt2yKpK8=
-github.com/shubham14bajpai/jiva-operator v0.0.0-20200117092318-399d844fdbbd/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
-github.com/shubham14bajpai/jiva-operator v0.0.0-20200129140224-a3a1919cdf15 h1:f0juOmO+NlPawvT68naJ4QeJz3103KTjOEvwERrGloo=
-github.com/shubham14bajpai/jiva-operator v0.0.0-20200129140224-a3a1919cdf15/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/shurcooL/sanitized_anchor_name v0.0.0-20151028001915-10ef21a441db/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sigma/go-inotify v0.0.0-20181102212354-c87b6cf5033d/go.mod h1:stlh9OsqBQSdwxTxX73mu41BBtRbIpZLQ7flcAoxAfo=
 github.com/sirupsen/logrus v1.1.1/go.mod h1:zrgwTnHtNr00buQ1vSptGe8m1f/BbgsPukg8qsT7A+A=

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -18,7 +18,6 @@ package driver
 
 import (
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -198,8 +197,8 @@ func (cs *controller) isVolumeReady(volumeID string) (*jv.JivaVolume, error) {
 		}
 
 		interval = 5
-		repCount, rf := instance.Status.ReplicaCount, instance.Spec.ReplicationFactor
-		if strconv.Itoa(repCount) != rf {
+		repCount, rf := instance.Status.ReplicaCount, instance.Spec.Policy.Target.ReplicationFactor
+		if repCount != rf {
 			logrus.Warningf("All replicas are not up, RF: %v, ReplicaCount: %v", rf, repCount)
 			continue
 		}
@@ -219,7 +218,7 @@ func (cs *controller) isVolumeReady(volumeID string) (*jv.JivaVolume, error) {
 			}
 		}
 
-		desired, _ := strconv.Atoi(rf)
+		desired := rf
 		if cnt == desired {
 			break
 		}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -394,6 +394,15 @@ func (ns *node) NodePublishVolume(
 	// Volume may be mounted at targetPath (bind mount in NodePublish)
 	if err := ns.isAlreadyMounted(volumeID, target); err != nil {
 		return nil, err
+	// JivaVolume CR may be updated by jiva-operator
+	instance, err := ns.client.GetJivaVolume(req.VolumeId)
+	if err != nil {
+		return nil, err
+	}
+
+	instance.Spec.MountInfo.TargetPath = target
+	if err := ns.client.UpdateJivaVolume(instance); err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
 	}
 
 	mountOptions := []string{"bind"}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -394,6 +394,8 @@ func (ns *node) NodePublishVolume(
 	// Volume may be mounted at targetPath (bind mount in NodePublish)
 	if err := ns.isAlreadyMounted(volumeID, target); err != nil {
 		return nil, err
+	}
+
 	// JivaVolume CR may be updated by jiva-operator
 	instance, err := ns.client.GetJivaVolume(req.VolumeId)
 	if err != nil {

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -397,7 +397,7 @@ func (ns *node) NodePublishVolume(
 	}
 
 	// JivaVolume CR may be updated by jiva-operator
-	instance, err := ns.client.GetJivaVolume(req.VolumeId)
+	instance, err := ns.doesVolumeExist(volumeID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -396,17 +396,6 @@ func (ns *node) NodePublishVolume(
 		return nil, err
 	}
 
-	// JivaVolume CR may be updated by jiva-operator
-	instance, err := ns.doesVolumeExist(volumeID)
-	if err != nil {
-		return nil, err
-	}
-
-	instance.Spec.MountInfo.TargetPath = target
-	if err := ns.client.UpdateJivaVolume(instance); err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-
 	mountOptions := []string{"bind"}
 	if req.GetReadonly() {
 		mountOptions = append(mountOptions, "ro")

--- a/pkg/jivavolume/jivavolume.go
+++ b/pkg/jivavolume/jivavolume.go
@@ -21,54 +21,6 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	jv "github.com/openebs/jiva-operator/pkg/apis/openebs/v1alpha1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-)
-
-const (
-	defaultReplicaSC = "openebs-hostpath"
-)
-
-var (
-	zero              int64
-	defaultTargetSpec = jv.TargetSpec{
-		ReplicationFactor: 3,
-		AuxResources:      &corev1.ResourceRequirements{},
-		PodTemplateResources: jv.PodTemplateResources{
-			Resources: &corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("0"),
-					corev1.ResourceMemory: resource.MustParse("0"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("0"),
-					corev1.ResourceMemory: resource.MustParse("0"),
-				},
-			},
-			Tolerations:       []corev1.Toleration{},
-			NodeSelector:      nil,
-			PriorityClassName: "",
-			Affinity:          &corev1.Affinity{},
-		},
-	}
-	defaultReplicaSpec = jv.ReplicaSpec{
-		PodTemplateResources: jv.PodTemplateResources{
-			Resources: &corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("0"),
-					corev1.ResourceMemory: resource.MustParse("0"),
-				},
-				Limits: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("0"),
-					corev1.ResourceMemory: resource.MustParse("0"),
-				},
-			},
-			Tolerations:       nil,
-			NodeSelector:      nil,
-			PriorityClassName: "",
-			Affinity:          &corev1.Affinity{},
-		},
-	}
 )
 
 // Jiva wraps the JivaVolume structure

--- a/pkg/jivavolume/jivavolume.go
+++ b/pkg/jivavolume/jivavolume.go
@@ -21,6 +21,54 @@ import (
 
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	jv "github.com/openebs/jiva-operator/pkg/apis/openebs/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+)
+
+const (
+	defaultReplicaSC = "openebs-hostpath"
+)
+
+var (
+	zero              int64
+	defaultTargetSpec = jv.TargetSpec{
+		ReplicationFactor: 3,
+		AuxResources:      &corev1.ResourceRequirements{},
+		PodTemplateResources: jv.PodTemplateResources{
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+			},
+			Tolerations:       []corev1.Toleration{},
+			NodeSelector:      nil,
+			PriorityClassName: "",
+			Affinity:          &corev1.Affinity{},
+		},
+	}
+	defaultReplicaSpec = jv.ReplicaSpec{
+		PodTemplateResources: jv.PodTemplateResources{
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+				Limits: corev1.ResourceList{
+					corev1.ResourceCPU:    resource.MustParse("0"),
+					corev1.ResourceMemory: resource.MustParse("0"),
+				},
+			},
+			Tolerations:       nil,
+			NodeSelector:      nil,
+			PriorityClassName: "",
+			Affinity:          &corev1.Affinity{},
+		},
+	}
 )
 
 // Jiva wraps the JivaVolume structure
@@ -102,16 +150,89 @@ func HasResourceParameters(req *csi.CreateVolumeRequest) ResourceParameters {
 	}
 }
 
-// WithReplicaStorageClass returns storage class
-func WithReplicaStorageClass(sc string) string {
-	if sc == "" {
-		return "openebs-hostpath"
-	}
-	return sc
-}
-
 // WithSpec defines the Spec field of JivaVolume
 func (j *Jiva) WithSpec(spec jv.JivaVolumeSpec) *Jiva {
 	j.jvObj.Spec = spec
+	return j
+}
+
+// WithPV defines the PV field of JivaVolumeSpec
+func (j *Jiva) WithPV(pvName string) *Jiva {
+	j.jvObj.Spec.PV = pvName
+	return j
+}
+
+// WithCapacity defines the Capacity field of JivaVolumeSpec
+func (j *Jiva) WithCapacity(capacity string) *Jiva {
+	j.jvObj.Spec.Capacity = capacity
+	return j
+}
+
+// WithReplicaSC defines the ReplicaSC field of JivaVolumePolicySpec
+func (j *Jiva) WithReplicaSC(scName string) *Jiva {
+	if scName == "" {
+		scName = defaultReplicaSC
+	}
+	j.jvObj.Spec.Policy.ReplicaSC = scName
+	return j
+}
+
+// WithEnableBufio defines the ReplicaSC field of JivaVolumePolicySpec
+func (j *Jiva) WithEnableBufio(enable bool) *Jiva {
+	j.jvObj.Spec.Policy.EnableBufio = enable
+	return j
+}
+
+// WithAutoScaling defines the ReplicaSC field of JivaVolumePolicySpec
+func (j *Jiva) WithAutoScaling(enable bool) *Jiva {
+	j.jvObj.Spec.Policy.AutoScaling = enable
+	return j
+}
+
+// WithTarget defines the ReplicaSC field of JivaVolumePolicySpec
+func (j *Jiva) WithTarget(target jv.TargetSpec) *Jiva {
+	if target.ReplicationFactor == 0 {
+		target.ReplicationFactor = defaultTargetSpec.ReplicationFactor
+	}
+	if target.AuxResources == nil {
+		target.AuxResources = defaultTargetSpec.AuxResources
+	}
+	if target.Resources == nil {
+		target.Resources = defaultTargetSpec.Resources
+	}
+	if target.Tolerations == nil {
+		target.Tolerations = defaultTargetSpec.Tolerations
+	}
+	if target.Affinity == nil {
+		target.Affinity = defaultTargetSpec.Affinity
+	}
+	if target.NodeSelector == nil {
+		target.NodeSelector = defaultTargetSpec.NodeSelector
+	}
+	if target.PriorityClassName == "" {
+		target.PriorityClassName = defaultTargetSpec.PriorityClassName
+	}
+	j.jvObj.Spec.Policy.Target = target
+	return j
+}
+
+// WithReplica defines the ReplicaSC field of JivaVolumePolicySpec
+func (j *Jiva) WithReplica(replica jv.ReplicaSpec) *Jiva {
+	if replica.Resources == nil {
+		replica.Resources = defaultReplicaSpec.Resources
+	}
+	if replica.Tolerations == nil {
+		replica.Tolerations = defaultReplicaSpec.Tolerations
+	}
+	if replica.Affinity == nil {
+		replica.Affinity = defaultReplicaSpec.Affinity
+	}
+	if replica.NodeSelector == nil {
+		replica.NodeSelector = defaultReplicaSpec.NodeSelector
+	}
+	if replica.PriorityClassName == "" {
+		replica.PriorityClassName = defaultReplicaSpec.PriorityClassName
+	}
+	j.jvObj.Spec.Policy.Replica = replica
 	return j
 }

--- a/pkg/jivavolume/jivavolume.go
+++ b/pkg/jivavolume/jivavolume.go
@@ -135,6 +135,17 @@ func (j *Jiva) WithLabels(labels map[string]string) *Jiva {
 	return j
 }
 
+// WithAnnotations is used to set the annotations in JivaVolume CR
+func (j *Jiva) WithAnnotations(annotations map[string]string) *Jiva {
+	if annotations != nil {
+		j.jvObj.Annotations = annotations
+	} else {
+		j.Errs = append(j.Errs,
+			errors.New("failed to initialize JivaVolume: annotations are missing"))
+	}
+	return j
+}
+
 // ResourceParameters is a function type which return resource values
 type ResourceParameters func(param string) string
 
@@ -150,12 +161,6 @@ func HasResourceParameters(req *csi.CreateVolumeRequest) ResourceParameters {
 	}
 }
 
-// WithSpec defines the Spec field of JivaVolume
-func (j *Jiva) WithSpec(spec jv.JivaVolumeSpec) *Jiva {
-	j.jvObj.Spec = spec
-	return j
-}
-
 // WithPV defines the PV field of JivaVolumeSpec
 func (j *Jiva) WithPV(pvName string) *Jiva {
 	j.jvObj.Spec.PV = pvName
@@ -165,74 +170,5 @@ func (j *Jiva) WithPV(pvName string) *Jiva {
 // WithCapacity defines the Capacity field of JivaVolumeSpec
 func (j *Jiva) WithCapacity(capacity string) *Jiva {
 	j.jvObj.Spec.Capacity = capacity
-	return j
-}
-
-// WithReplicaSC defines the ReplicaSC field of JivaVolumePolicySpec
-func (j *Jiva) WithReplicaSC(scName string) *Jiva {
-	if scName == "" {
-		scName = defaultReplicaSC
-	}
-	j.jvObj.Spec.Policy.ReplicaSC = scName
-	return j
-}
-
-// WithEnableBufio defines the ReplicaSC field of JivaVolumePolicySpec
-func (j *Jiva) WithEnableBufio(enable bool) *Jiva {
-	j.jvObj.Spec.Policy.EnableBufio = enable
-	return j
-}
-
-// WithAutoScaling defines the ReplicaSC field of JivaVolumePolicySpec
-func (j *Jiva) WithAutoScaling(enable bool) *Jiva {
-	j.jvObj.Spec.Policy.AutoScaling = enable
-	return j
-}
-
-// WithTarget defines the ReplicaSC field of JivaVolumePolicySpec
-func (j *Jiva) WithTarget(target jv.TargetSpec) *Jiva {
-	if target.ReplicationFactor == 0 {
-		target.ReplicationFactor = defaultTargetSpec.ReplicationFactor
-	}
-	if target.AuxResources == nil {
-		target.AuxResources = defaultTargetSpec.AuxResources
-	}
-	if target.Resources == nil {
-		target.Resources = defaultTargetSpec.Resources
-	}
-	if target.Tolerations == nil {
-		target.Tolerations = defaultTargetSpec.Tolerations
-	}
-	if target.Affinity == nil {
-		target.Affinity = defaultTargetSpec.Affinity
-	}
-	if target.NodeSelector == nil {
-		target.NodeSelector = defaultTargetSpec.NodeSelector
-	}
-	if target.PriorityClassName == "" {
-		target.PriorityClassName = defaultTargetSpec.PriorityClassName
-	}
-	j.jvObj.Spec.Policy.Target = target
-	return j
-}
-
-// WithReplica defines the ReplicaSC field of JivaVolumePolicySpec
-func (j *Jiva) WithReplica(replica jv.ReplicaSpec) *Jiva {
-	if replica.Resources == nil {
-		replica.Resources = defaultReplicaSpec.Resources
-	}
-	if replica.Tolerations == nil {
-		replica.Tolerations = defaultReplicaSpec.Tolerations
-	}
-	if replica.Affinity == nil {
-		replica.Affinity = defaultReplicaSpec.Affinity
-	}
-	if replica.NodeSelector == nil {
-		replica.NodeSelector = defaultReplicaSpec.NodeSelector
-	}
-	if replica.PriorityClassName == "" {
-		replica.PriorityClassName = defaultReplicaSpec.PriorityClassName
-	}
-	j.jvObj.Spec.Policy.Replica = replica
 	return j
 }


### PR DESCRIPTION
Signed-off-by: shubham shubham.bajpai@mayadata.io
This PR adds changes corresponding to the schema changes made to JivaVolume and JivaVolumePolicy CRDs. This PR also updates the target path in the JivaVolume spec. The policy name for the volume will be passed as an annotation to the JivaVolume CR.
Refer: https://github.com/openebs/jiva-operator/pull/8