### PR TITLE
feat(jiva-csi): remount volume if marked as ro by fs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,6 @@ script:
   - cd $GOPATH/src/github.com/openebs/jiva-operator
   - wget https://raw.githubusercontent.com/openebs/openebs/master/k8s/openebs-operator.yaml
   - kubectl apply -f openebs-operator.yaml
-  - kubectl apply -f deploy/crds/openebs_v1alpha1_jivavolume_crd.yaml
   - kubectl apply -f deploy/
   - cd ${TRAVIS_BUILD_DIR}
   - kubectl apply -f deploy/jiva-csi-ubuntu-16.04.yaml

--- a/deploy/jiva-csi-ubuntu-16.04.yaml
+++ b/deploy/jiva-csi-ubuntu-16.04.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--name=jiva.csi.openebs.io"
-            - "--nodeid=$(OPENEBS_NODEID)"
+            - "--nodeid=$(OPENEBS_NODE_ID)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
             # enableiscsidebug is used to enable debug logs for iscsi operations

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -269,7 +269,7 @@ spec:
           imagePullPolicy: IfNotPresent
           args:
             - "--name=jiva.csi.openebs.io"
-            - "--nodeid=$(OPENEBS_NODEID)"
+            - "--nodeid=$(OPENEBS_NODE_ID)"
             - "--endpoint=$(OPENEBS_CSI_ENDPOINT)"
             - "--plugin=$(OPENEBS_NODE_DRIVER)"
             # enableiscsidebug is used to enable debug logs for iscsi operations

--- a/deploy/jiva-csi.yaml
+++ b/deploy/jiva-csi.yaml
@@ -297,6 +297,10 @@ spec:
               value: node
             - name: OPENEBS_NAMESPACE
               value: openebs
+            # REMOUNT: if set true/True volume will be automatically remounted
+            # in case if the mountpoint goes to ro state
+            - name: REMOUNT
+              value: True
           volumeMounts:
             - name: plugin-dir
               mountPath: /plugin

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 )
 
 replace (
+	github.com/openebs/jiva-operator => github.com/utkarshmani1997/jiva-operator-1 v0.0.0-20200120064421-050e9f037a2d
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/container-storage-interface/spec v1.1.0
 	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20191120152119-1430b53a1741
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
-	github.com/openebs/jiva-operator v0.0.0-20191128062733-08c184aa7f8a
+	github.com/openebs/jiva-operator v0.0.0-20200121055138-784b9dcc671c
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/net v0.0.0-20190812203447-cdfb69ac37fc
@@ -24,7 +24,6 @@ require (
 )
 
 replace (
-	github.com/openebs/jiva-operator => github.com/utkarshmani1997/jiva-operator-1 v0.0.0-20200120064421-050e9f037a2d
 	k8s.io/api => k8s.io/api v0.0.0-20190620084959-7cf5895f2711
 	k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.0.0-20190620085554-14e95df34f1f
 	k8s.io/apimachinery => k8s.io/apimachinery v0.0.0-20190612205821-1799e75a0719

--- a/go.sum
+++ b/go.sum
@@ -379,6 +379,8 @@ github.com/opencontainers/image-spec v0.0.0-20170604055404-372ad780f634/go.mod h
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
+github.com/openebs/jiva-operator v0.0.0-20200121055138-784b9dcc671c h1:/f5F1a9PjldZ9t8AmtLfQhPREngFpUwCU+i9TMJdDVQ=
+github.com/openebs/jiva-operator v0.0.0-20200121055138-784b9dcc671c/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
@@ -503,8 +505,6 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181022190402-e5e69e061d4f/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
-github.com/utkarshmani1997/jiva-operator-1 v0.0.0-20200120064421-050e9f037a2d h1:3KGINzevXedl7WZY1HfEBkrygSeUjS23pNzFPnANWBo=
-github.com/utkarshmani1997/jiva-operator-1 v0.0.0-20200120064421-050e9f037a2d/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware/govmomi v0.20.1/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,6 @@ github.com/opencontainers/image-spec v0.0.0-20170604055404-372ad780f634/go.mod h
 github.com/opencontainers/runc v0.0.0-20181113202123-f000fe11ece1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v1.0.0/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/selinux v0.0.0-20170621221121-4a2974bf1ee9/go.mod h1:+BLncwf63G4dgOzykXAxcmnFlUaOlkDdmw/CqsW6pjs=
-github.com/openebs/jiva-operator v0.0.0-20191128062733-08c184aa7f8a h1:/dMmoSb4r3VhsGMy5dG0/HTF7bMzDOyzE8NRemW73RY=
-github.com/openebs/jiva-operator v0.0.0-20191128062733-08c184aa7f8a/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/openshift/api v3.9.1-0.20190424152011-77b8897ec79a+incompatible/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/openshift/client-go v0.0.0-20190401163519-84c2b942258a/go.mod h1:6rzn+JTr7+WYS2E1TExP4gByoABxMznR6y2SnUIkmxk=
 github.com/openshift/origin v0.0.0-20160503220234-8f127d736703/go.mod h1:0Rox5r9C8aQn6j1oAOQ0c1uC86mYbUFObzjBRvUKHII=
@@ -505,6 +503,8 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/ugorji/go/codec v0.0.0-20181022190402-e5e69e061d4f/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/urfave/negroni v1.0.0/go.mod h1:Meg73S6kFm/4PpbYdq35yYWoCZ9mS/YSx+lKnmiohz4=
+github.com/utkarshmani1997/jiva-operator-1 v0.0.0-20200120064421-050e9f037a2d h1:3KGINzevXedl7WZY1HfEBkrygSeUjS23pNzFPnANWBo=
+github.com/utkarshmani1997/jiva-operator-1 v0.0.0-20200120064421-050e9f037a2d/go.mod h1:xxGmb6r4sZaY02Z9/iUMNgOvwXnZIp8pvAW0nHyK9B4=
 github.com/vishvananda/netlink v0.0.0-20171020171820-b2de5d10e38e/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netns v0.0.0-20171111001504-be1fbeda1936/go.mod h1:ZjcWmFBXmLKZu9Nxj3WKYEafiSqer2rnvPr0en9UNpI=
 github.com/vmware/govmomi v0.20.1/go.mod h1:URlwyTFZX72RmxtxuaFL2Uj3fD1JTvZdx59bHWk6aFU=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -42,13 +42,6 @@ type Config struct {
 	// in case of topologies and publishing or
 	// unpublishing volumes on nodes
 	NodeID string
-
-	// A REST Server is exposed on this URL for internal
-	// operations and Day-2 ops
-	RestURL string
-
-	// CASEngine is the storage engine to be provisioned
-	CASEngine string
 }
 
 // Default returns a new instance of config

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -70,7 +70,7 @@ func (cs *controller) CreateVolume(
 
 	// set client each time to avoid caching issue
 	if err := cs.client.Set(); err != nil {
-		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to set client, err: %v", err)
+		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to set client, err: {%v}", err)
 	}
 
 	if err := cs.client.CreateJivaVolume(req); err != nil {
@@ -94,17 +94,17 @@ func (cs *controller) DeleteVolume(
 	if volID == "" {
 		return nil, status.Error(
 			codes.InvalidArgument,
-			"failed to validate volume create request: missing volume name",
+			"Failed to validate volume create request: missing volume name",
 		)
 	}
 	volID = strings.ToLower(volID)
 	// set client each time to avoid caching issue
 	if err := cs.client.Set(); err != nil {
-		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to set client, err: %v", err)
+		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to set client, err: {%v}", err)
 	}
 
 	if err := cs.client.DeleteJivaVolume(volID); err != nil {
-		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to delete volume {%v}, err: %v", req.VolumeId, err)
+		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to delete volume {%v}, err: {%v}", req.VolumeId, err)
 	}
 
 	logrus.Infof("DeleteVolume: volume {%s} is deleted", req.VolumeId)
@@ -133,7 +133,7 @@ func (cs *controller) ValidateVolumeCapabilities(
 
 	// set client each time to avoid caching issue
 	if err := cs.client.Set(); err != nil {
-		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to set client, err: %v", err)
+		return nil, status.Errorf(codes.Internal, "DeleteVolume: failed to set client, err: {%v}", err)
 	}
 
 	if _, err := cs.client.GetJivaVolume(volumeID); err != nil {
@@ -316,7 +316,7 @@ func (cs *controller) validateVolumeCreateReq(req *csi.CreateVolumeRequest) erro
 	if req.GetName() == "" {
 		return status.Error(
 			codes.InvalidArgument,
-			"failed to validate volume create request: missing volume name",
+			"Failed to validate volume create request: missing volume name",
 		)
 	}
 
@@ -324,14 +324,14 @@ func (cs *controller) validateVolumeCreateReq(req *csi.CreateVolumeRequest) erro
 	if volCapabilities == nil {
 		return status.Error(
 			codes.InvalidArgument,
-			"failed to get volume capabilities: missing volume capabilities",
+			"Failed to get volume capabilities: missing volume capabilities",
 		)
 	}
 
 	if !isValidVolumeCapabilities(volCapabilities) {
 		return status.Error(
 			codes.InvalidArgument,
-			"failed to validate volume capabilities")
+			"Failed to validate volume capabilities")
 	}
 
 	return nil

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -81,8 +81,7 @@ func New(config *config.Config, cli *client.Client) *CSIDriver {
 		if remount == "true" || remount == "True" {
 			nm := newNodeMounterWithOpts(
 				withClient(cli),
-				withNodeID(config.NodeID),
-				withReqTransition(ns.VolumeTransition))
+				withNodeID(config.NodeID))
 			go nm.MonitorMounts()
 		}
 		driver.ns = ns

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -17,6 +17,8 @@ limitations under the License.
 package driver
 
 import (
+	"os"
+
 	"github.com/container-storage-interface/spec/lib/go/csi"
 	config "github.com/openebs/jiva-csi/pkg/config"
 	"github.com/openebs/jiva-csi/pkg/kubernetes/client"
@@ -74,7 +76,16 @@ func New(config *config.Config, cli *client.Client) *CSIDriver {
 		driver.cs = NewController(cli)
 
 	case "node":
-		driver.ns = NewNode(driver, cli)
+		ns := NewNode(driver, cli)
+		remount := os.Getenv("REMOUNT")
+		if remount == "true" || remount == "True" {
+			nm := newNodeMounterWithOpts(
+				withClient(cli),
+				withNodeID(config.NodeID),
+				withReqTransition(ns.VolumeTransition))
+			go nm.MonitorMounts()
+		}
+		driver.ns = ns
 	}
 
 	// Identity server is common to both node and

--- a/pkg/driver/grpc.go
+++ b/pkg/driver/grpc.go
@@ -46,13 +46,13 @@ func parseEndpoint(ep string) (string, string, error) {
 // logGRPC logs all the grpc related errors, i.e the final errors
 // which are returned to the grpc clients
 func logGRPC(ctx context.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-	logrus.Infof("GRPC call: %s", info.FullMethod)
-	logrus.Infof("GRPC request: %s", protosanitizer.StripSecrets(req))
+	logrus.Debugf("GRPC call: %s", info.FullMethod)
+	logrus.Debugf("GRPC request: %s", protosanitizer.StripSecrets(req))
 	resp, err := handler(ctx, req)
 	if err != nil {
 		logrus.Errorf("GRPC error: %v", err)
 	} else {
-		logrus.Infof("GRPC response: %s", protosanitizer.StripSecrets(resp))
+		logrus.Debugf("GRPC response: %s", protosanitizer.StripSecrets(resp))
 	}
 	return resp, err
 }

--- a/pkg/driver/mount.go
+++ b/pkg/driver/mount.go
@@ -120,19 +120,19 @@ func waitForVolumeToBeReady(volID string, cli *client.Client) (*jv.JivaVolume, e
 			if instance.Status.Status == "RO" {
 				replicaStatus := instance.Status.ReplicaStatuses
 				if len(replicaStatus) != 0 {
-					logrus.Warningf("Volume {%v} is in RO mode: replica status: {%+v}", volID, replicaStatus)
+					logrus.Warningf("Volume: {%v} is in RO mode: replica status: {%+v}", volID, replicaStatus)
 					continue
 				}
-				logrus.Warningf("Volume {%v} is not ready: replicas may not be connected", volID)
+				logrus.Warningf("Volume: {%v} is not ready: replicas may not be connected", volID)
 				continue
 			}
-			logrus.Warningf("Volume {%v} is not ready: volume status is %s", volID, instance.Status.Status)
+			logrus.Warningf("Volume: {%v} is not ready: volume status is {%s}", volID, instance.Status.Status)
 			continue
 		} else {
 			break
 		}
 	}
-	return nil, fmt.Errorf("Max retry count exceeded, volume {%v} is not ready", volID)
+	return nil, fmt.Errorf("Max retry count exceeded, volume: {%v} is not ready", volID)
 }
 
 func waitForVolumeToBeReachable(targetPortal string) error {
@@ -146,7 +146,7 @@ func waitForVolumeToBeReachable(targetPortal string) error {
 		// Create a connection to test if the iSCSI Portal is reachable,
 		if conn, err = net.Dial("tcp", targetPortal); err == nil {
 			conn.Close()
-			logrus.Debugf("Target {%v} is reachable to create connections", targetPortal)
+			logrus.Debugf("Target: {%v} is reachable to create connections", targetPortal)
 			return nil
 		}
 		// wait until the iSCSI targetPortal is reachable
@@ -160,7 +160,7 @@ func waitForVolumeToBeReachable(targetPortal string) error {
 			// based on the kubelets retrying logic. Kubelet retries to publish
 			// volume after every 14s )
 			return fmt.Errorf(
-				"iSCSI Target not reachable, TargetPortal {%v}, err:%v",
+				"iSCSI Target not reachable, TargetPortal: {%v}, err: {%v}",
 				targetPortal, err)
 		}
 	}
@@ -200,21 +200,21 @@ func (n *NodeMounter) MonitorMounts() {
 		select {
 		case <-ticker.C:
 			if mountList, err = n.List(); err != nil {
-				logrus.Debugf("MonitorMounts: failed to get list of mount paths, err: %v", err)
+				logrus.Debugf("MonitorMounts: failed to get list of mount paths, err: {%v}", err)
 				break
 			}
 
 			// reset the client to avoid caching issue
 			err = n.client.Set()
 			if err != nil {
-				logrus.Warningf("MonitorMounts: failed to set client, err: %v", err)
+				logrus.Warningf("MonitorMounts: failed to set client, err: {%v}", err)
 				continue
 			}
 
 			if csivolList, err = n.client.ListJivaVolumeWithOpts(map[string]string{
 				"nodeID": n.nodeID,
 			}); err != nil {
-				logrus.Debugf("MonitorMounts: failed to get list of jiva volumes attached to this node, err: %v", err)
+				logrus.Debugf("MonitorMounts: failed to get list of jiva volumes attached to this node, err: {%v}", err)
 				break
 			}
 			for _, vol := range csivolList.Items {
@@ -265,10 +265,11 @@ func (n *NodeMounter) remount(vol jv.JivaVolume, stagingPathExists, targetPathEx
 		return
 	}
 
-	logrus.Infof("Remounting volume: {%s} at\nStagingPath: %s\nTargetPath: %s",
+	logrus.Infof("Remount: mount volume {%s} at StagingPath: {%s}, TargetPath: {%s}",
 		vol.Name, vol.Spec.MountInfo.StagingPath,
 		vol.Spec.MountInfo.TargetPath)
 	defer func() {
+		logrus.Infof("Remount: mount operation of volume: {%s} is finished", vol.Name)
 		n.req.Delete(vol.Name)
 	}()
 
@@ -277,12 +278,12 @@ func (n *NodeMounter) remount(vol jv.JivaVolume, stagingPathExists, targetPathEx
 		&vol,
 	); err != nil {
 		logrus.Errorf(
-			"Remount failed for vol: %s : err: %v",
+			"Remount: mount failed for volume: {%s}, err: {%v}",
 			vol.Name, err,
 		)
 	} else {
 		logrus.Infof(
-			"Remount successful for vol: %s",
+			"Remount: mount successful for volume: {%s}",
 			vol.Name,
 		)
 	}

--- a/pkg/driver/stats.go
+++ b/pkg/driver/stats.go
@@ -24,6 +24,9 @@ import (
 func getStatistics(volumePath string) ([]*csi.VolumeUsage, error) {
 	var statfs unix.Statfs_t
 	// See http://man7.org/linux/man-pages/man2/statfs.2.html for details.
+	// TODO:
+	// This syscall may hang under some situations, need to find some way
+	// to cancel the execution of this function
 	err := unix.Statfs(volumePath, &statfs)
 	if err != nil {
 		return nil, err

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -95,11 +95,11 @@ func (cl *Client) GetJivaVolume(name string) (*jv.JivaVolume, error) {
 	instance, err := cl.ListJivaVolume(name)
 	if err != nil {
 		logrus.Errorf("Failed to get JivaVolume CR: %v, err: %v", name, err)
-		return nil, status.Errorf(codes.Internal, "failed to get JivaVolume CR: {%v}, err: %v", name, err)
+		return nil, status.Errorf(codes.Internal, "Failed to get JivaVolume CR: {%v}, err: {%v}", name, err)
 	}
 
 	if len(instance.Items) == 0 {
-		return nil, status.Errorf(codes.NotFound, "failed to get JivaVolume CR: {%v}", name)
+		return nil, status.Errorf(codes.NotFound, "Failed to get JivaVolume CR: {%v}", name)
 	}
 
 	return &instance.Items[0], nil
@@ -109,7 +109,7 @@ func (cl *Client) GetJivaVolume(name string) (*jv.JivaVolume, error) {
 func (cl *Client) UpdateJivaVolume(cr *jv.JivaVolume) error {
 	err := cl.client.Update(context.TODO(), cr)
 	if err != nil {
-		logrus.Errorf("Failed to update JivaVolume CR: %v, err: %v", cr.Name, err)
+		logrus.Errorf("Failed to update JivaVolume CR: {%v}, err: {%v}", cr.Name, err)
 		return err
 	}
 	return nil
@@ -135,7 +135,7 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) error {
 	}
 
 	if req.GetCapacityRange() == nil {
-		logrus.Warningf("CreateVolume: capacity range is nil, provisioning with default size: %v (bytes)", defaultSizeBytes)
+		logrus.Warningf("CreateVolume: capacity range is nil, provisioning with default size: {%v (bytes)}", defaultSizeBytes)
 		sizeBytes = defaultSizeBytes
 	} else {
 		sizeBytes = req.GetCapacityRange().RequiredBytes
@@ -190,7 +190,7 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) error {
 		})
 
 	if jiva.Errs != nil {
-		return status.Errorf(codes.Internal, "failed to build JivaVolume CR, err: %v", jiva.Errs)
+		return status.Errorf(codes.Internal, "Failed to build JivaVolume CR, err: {%v}", jiva.Errs)
 	}
 
 	obj := jiva.Instance()
@@ -200,15 +200,15 @@ func (cl *Client) CreateJivaVolume(req *csi.CreateVolumeRequest) error {
 		logrus.Infof("Creating a new JivaVolume CR {name: %v, namespace: %v}", name, ns)
 		err = cl.client.Create(context.TODO(), obj)
 		if err != nil {
-			return status.Errorf(codes.Internal, "failed to create JivaVolume CR, err: %v", err)
+			return status.Errorf(codes.Internal, "Failed to create JivaVolume CR, err: {%v}", err)
 		}
 		return nil
 	} else if err != nil {
-		return status.Errorf(codes.Internal, "failed to get the JivaVolume details, err: %v", err)
+		return status.Errorf(codes.Internal, "Failed to get the JivaVolume details, err: {%v}", err)
 	}
 
 	if objExists.Spec.Capacity != obj.Spec.Capacity {
-		return status.Errorf(codes.AlreadyExists, "failed to create JivaVolume CR, volume with different size already exists")
+		return status.Errorf(codes.AlreadyExists, "Failed to create JivaVolume CR, volume with different size already exists")
 	}
 
 	return nil

--- a/pkg/kubernetes/client/client.go
+++ b/pkg/kubernetes/client/client.go
@@ -229,6 +229,20 @@ func (cl *Client) ListJivaVolume(volumeID string) (*jv.JivaVolumeList, error) {
 	return obj, nil
 }
 
+// ListJivaVolumeWithOpts returns the list of JivaVolume resources
+func (cl *Client) ListJivaVolumeWithOpts(opts map[string]string) (*jv.JivaVolumeList, error) {
+	obj := &jv.JivaVolumeList{}
+	options := []client.ListOption{
+		client.MatchingLabels(opts),
+	}
+
+	if err := cl.client.List(context.TODO(), obj, options...); err != nil {
+		return nil, err
+	}
+
+	return obj, nil
+}
+
 // DeleteJivaVolume delete the JivaVolume CR
 func (cl *Client) DeleteJivaVolume(volumeID string) error {
 	obj, err := cl.ListJivaVolume(volumeID)

--- a/pkg/request/request.go
+++ b/pkg/request/request.go
@@ -1,52 +1,38 @@
 package request
 
 import (
+	"fmt"
 	"sync"
 )
 
-// Transition is a struct used to manage inflight volume creation request.
-type Transition struct {
-	mux    *sync.Mutex
-	volume map[string]string
+var (
+
+	// TransitionVolList contains the list of volumes under transition
+	// This list is protected by TransitionVolListLock
+	TransitionVolList map[string]string
+
+	// TransitionVolListLock is required to protect the above Volumes list
+	TransitionVolListLock sync.RWMutex
+)
+
+func init() {
+	TransitionVolList = make(map[string]string)
 }
 
-// NewTransition instanciates Transition.
-func NewTransition() *Transition {
-	return &Transition{
-		mux:    &sync.Mutex{},
-		volume: make(map[string]string),
+func RemoveVolumeFromTransitionList(volumeID string) {
+	TransitionVolListLock.Lock()
+	defer TransitionVolListLock.Unlock()
+	delete(TransitionVolList, volumeID)
+}
+
+func AddVolumeToTransitionList(volumeID string, req string) error {
+	TransitionVolListLock.Lock()
+	defer TransitionVolListLock.Unlock()
+
+	if _, ok := TransitionVolList[volumeID]; ok {
+		return fmt.Errorf("Volume Busy, %v is already in progress",
+			TransitionVolList[volumeID])
 	}
-}
-
-func (t *Transition) GetOperation(volID string) string {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
-	_, ok := t.volume[volID]
-	if ok {
-		return t.volume[volID]
-	}
-	return ""
-}
-
-// Insert insert the volume create req hash into map
-func (t *Transition) Insert(volID string, ops string) bool {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
-	_, ok := t.volume[volID]
-	if ok {
-		return false
-	}
-
-	t.volume[volID] = ops
-	return true
-}
-
-// Delete removes the req from the map
-func (t *Transition) Delete(volID string) {
-	t.mux.Lock()
-	defer t.mux.Unlock()
-
-	delete(t.volume, volID)
+	TransitionVolList[volumeID] = req
+	return nil
 }


### PR DESCRIPTION
iSCSI volumes go to RO if target is not reachable for more than 120s (default)
or if target is not allowing IO's for more than default timeout. Remount
feature, if enabled, launch a goroutine in background and monitor the mount
paths and remount to RW.

Add request info if any operation on the given volume is already in progress

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>