### PR TITLE
fix(travis): remove exit 0 from policy create

### DIFF
--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -126,7 +126,6 @@ function createJivaVolumePolicy() {
 		dumpAllLogs
 		exit 1
 	fi
-	exit 0
 }
 
 initializeTestEnv


### PR DESCRIPTION
Signed-off-by: shubham <shubham.bajpai@mayadata.io>
This PR removes `exit 0` from create policy function which was preventing tests from running.