### PR TITLE
fix(node-driver): only rescan the volume to be resized

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,38 @@ openebs-jiva-csi-node-56t5g     2/2     Running   0          6m13s
 
 ### Provision a Jiva volume
 
-1. Create a Storage Class to dynamically provision volumes
+1. Create Jiva volume policy to set various policies for creating
+   jiva volume. Though this is optional as there are already some
+   default values are set for some field like replicaSC, replicationFactor
+   etc with default value openebs-hostpath and 3 respectively.
+   A sample jiva volume policy CR looks like:
+   ``` 
+    apiVersion: openebs.io/v1alpha1
+    kind: JivaVolumePolicy
+    metadata:
+      name: example-jivavolumepolicy
+      namespace: openebs
+    spec:
+      replicaSC: openebs-hostpath
+      enableBufio: false
+      autoScaling: false
+      target:
+        # monitor: false
+        replicationFactor: 1
+        # auxResources:
+        # tolerations:
+        # resources:
+        # affinity:
+        # nodeSelector:
+        # priorityClassName:
+      # replica:
+        # tolerations:
+        # resources:
+        # affinity:
+        # nodeSelector:
+        # priorityClassName:
+    ```
+2. Create a Storage Class to dynamically provision volumes
    using jiva-csi driver. A sample storage class looks like:
    ```
    apiVersion: storage.k8s.io/v1
@@ -71,8 +102,7 @@ openebs-jiva-csi-node-56t5g     2/2     Running   0          6m13s
    provisioner: jiva.csi.openebs.io
    parameters:
      cas-type: "jiva"
-     replicaCount: "1"
-     replicaSC: "openebs-hostpath"
+     policy: "example-jivavolumepolicy"
    ```
 2. Create PVC by specifying the above Storage Class in the PVC spec
    ```
@@ -88,7 +118,7 @@ openebs-jiva-csi-node-56t5g     2/2     Running   0          6m13s
        requests:
          storage: 4Gi
    ```
-3. Deploy your application by specifying the PVC name
+4. Deploy your application by specifying the PVC name
    ```
    apiVersion: apps/v1
    kind: Deployment

--- a/deploy/sample/fio.yaml
+++ b/deploy/sample/fio.yaml
@@ -6,8 +6,7 @@ provisioner: jiva.csi.openebs.io
 allowVolumeExpansion: true
 parameters:
   cas-type: "jiva"
-  replicaCount: "1"
-  replicaSC: "openebs-hostpath"
+  policy: "example-jivavolumepolicy"
 ---
 kind: PersistentVolumeClaim
 apiVersion: v1

--- a/pkg/driver/node.go
+++ b/pkg/driver/node.go
@@ -634,9 +634,11 @@ func (ns *node) NodeExpandVolume(
 	}
 
 	resize := resizeInput{
-		volumePath: volumePath,
-		fsType:     instance.Spec.MountInfo.FSType,
-		exec:       ns.mounter.Exec,
+		volumePath:   volumePath,
+		fsType:       instance.Spec.MountInfo.FSType,
+		iqn:          instance.Spec.ISCSISpec.Iqn,
+		targetPortal: instance.Spec.ISCSISpec.TargetIP,
+		exec:         ns.mounter.Exec,
 	}
 
 	list, err := ns.mounter.List()

--- a/pkg/driver/resize.go
+++ b/pkg/driver/resize.go
@@ -6,9 +6,11 @@ import (
 )
 
 type resizeInput struct {
-	volumePath string
-	fsType     string
-	exec       mount.Exec
+	volumePath   string
+	fsType       string
+	iqn          string
+	targetPortal string
+	exec         mount.Exec
 }
 
 func (r resizeInput) volume(list []mount.MountPoint) error {
@@ -35,7 +37,8 @@ func (r resizeInput) volume(list []mount.MountPoint) error {
 
 // ReScan rescans all the iSCSI sessions on the host
 func (r resizeInput) reScan() error {
-	out, err := r.exec.Run("iscsiadm", "-m", "session", "--rescan")
+	logrus.Info("Rescan ISCSI session")
+	out, err := r.exec.Run("iscsiadm", "-m", "node", "-T", r.iqn, "-P", r.targetPortal, "--rescan")
 	if err != nil {
 		logrus.Errorf("iscsi: rescan failed error: %s", string(out))
 		return err


### PR DESCRIPTION

- This commit fix the issue where resize was getting stuck due to stale iscsi sessions, since we were scanning all the sessions. Now it will only scan the session for the volume to be resized.
- Update README with the latest installing instructions

Signed-off-by: Utkarsh Mani Tripathi <utkarsh.tripathi@mayadata.io>