### PR TITLE
test(provisioning): add ginkgo tests for volume provisioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,8 @@ script:
   - cd ${TRAVIS_BUILD_DIR}
   - kubectl apply -f deploy/jiva-csi.yaml
   - ./ci/ci.sh
+  - cd ./tests
+  - make tests
 
 after_success:
   - make push

--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ else
 	export GIT_TAG
 endif
 
-PACKAGES = $(shell go list ./... | grep -v 'vendor')
+PACKAGES = $(shell go list ./... | grep -v 'vendor\|tests')
 
 LDFLAGS ?= \
         -extldflags "-static" \

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ EXTERNAL_TOOLS=\
 	golang.org/x/tools/cmd/cover \
 	github.com/axw/gocov/gocov \
 	github.com/ugorji/go/codec/codecgen \
+	github.com/onsi/ginkgo/ginkgo \
+	github.com/onsi/gomega/...
 
 # Lint our code. Reference: https://golang.org/cmd/vet/
 VETARGS?=-asmdecl -atomic -bool -buildtags -copylocks -methods \

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -147,3 +147,4 @@ waitForAllComponentsToBeReady
 createJivaVolumePolicy
 initializeCSISanitySuite
 startTestSuite
+cd tests; make tests

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -145,6 +145,6 @@ function createJivaVolumePolicy() {
 initializeTestEnv
 waitForAllComponentsToBeReady
 createJivaVolumePolicy
+cd tests; make tests
 initializeCSISanitySuite
 startTestSuite
-cd tests; make tests

--- a/ci/ci.sh
+++ b/ci/ci.sh
@@ -145,6 +145,5 @@ function createJivaVolumePolicy() {
 initializeTestEnv
 waitForAllComponentsToBeReady
 createJivaVolumePolicy
-cd tests; make tests
 initializeCSISanitySuite
 startTestSuite

--- a/go.mod
+++ b/go.mod
@@ -6,12 +6,15 @@ require (
 	github.com/container-storage-interface/spec v1.2.0
 	github.com/kubernetes-csi/csi-lib-iscsi v0.0.0-20191120152119-1430b53a1741
 	github.com/kubernetes-csi/csi-lib-utils v0.6.1
+	github.com/onsi/ginkgo v1.10.1
+	github.com/onsi/gomega v1.7.0
 	github.com/openebs/jiva-operator v1.12.2-0.20200929135617-d7f7f0d9e81d
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/cobra v0.0.5
 	golang.org/x/net v0.0.0-20191028085509-fe3aa8a45271
 	golang.org/x/sys v0.0.0-20191028164358-195ce5e7f934
 	google.golang.org/grpc v1.24.0
+	k8s.io/api v0.17.3
 	k8s.io/apimachinery v0.17.3
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/cloud-provider v0.17.3

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ bou.ke/monkey v1.0.1/go.mod h1:FgHuK96Rv2Nlf+0u1OOVDpCMdsWyOFmeeketDHE7LIg=
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.37.4/go.mod h1:NHPJ89PdicEuT9hdPXMROBD91xc5uRDxsMtSB16k7hw=
+cloud.google.com/go v0.38.0 h1:ROfEUZz+Gh5pa62DJWXSaonyu3StP6EA6lPEXPI6mCo=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
 github.com/Azure/azure-sdk-for-go v32.5.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-sdk-for-go v35.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,38 @@
+# Copyright © 2020 The OpenEBS Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+GOFLAGS=-mod=vendor
+export GOFLAGS
+GINKGO=$(GOPATH)/bin/ginkgo
+KUBECTL=/usr/local/bin/kubectl
+
+
+# If you want to change the Kubernetes version for e2e test, specify this variable from command line.
+# e.g. $ make TEST_KUBERNETES_VERSION=1.17 test
+TEST_KUBERNETES_VERSION=1.17
+
+ifeq ($(TEST_KUBERNETES_VERSION),1.17)
+KUBERNETES_VERSION=1.17.2
+endif
+
+
+tests:
+	  env \
+		PATH=$(PATH) \
+		GOPATH=$(GOPATH) \
+		GO111MODULE=on \
+		GOFLAGS=$(GOFLAGS) \
+		TEST_KUBERNETES_VERSION=$(TEST_KUBERNETES_VERSION) \
+		$(GINKGO) --failFast -v .
+

--- a/tests/kube_utils.go
+++ b/tests/kube_utils.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"bytes"
+	"os/exec"
+)
+
+func execAtLocal(cmd string, input []byte, args ...string) ([]byte, []byte, error) {
+	var stdout, stderr bytes.Buffer
+	command := exec.Command(cmd, args...)
+	command.Stdout = &stdout
+	command.Stderr = &stderr
+
+	if len(input) != 0 {
+		command.Stdin = bytes.NewReader(input)
+	}
+
+	err := command.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+func Kubectl(args ...string) ([]byte, []byte, error) {
+	return execAtLocal("kubectl", nil, args...)
+}
+
+func KubectlWithInput(input []byte, args ...string) ([]byte, []byte, error) {
+	return execAtLocal("kubectl", input, args...)
+}

--- a/tests/provision_test.go
+++ b/tests/provision_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("[csi] [jiva] TEST VOLUME PROVISIONING WITH APP POD RESTART", func() {
+	BeforeEach(prepareForVolumeCreationTest)
+	AfterEach(cleanupAfterVolumeCreationTest)
+
+	Context("App is deployed and restarted on pvc with replica count 1", func() {
+		It("Should run Volume Creation Test", volumeCreationTest)
+	})
+})
+
+func volumeCreationTest() {
+	By("creating and verifying PVC bound status", createAndVerifyPVC)
+	By("Creating and deploying app pod", createDeployVerifyApp)
+	By("Restarting app pod and verifying app pod running status", restartAppPodAndVerifyRunningStatus)
+	By("Deleting application deployment", deleteAppDeployment)
+	By("Deleting pvc", deletePVC)
+}
+
+func prepareForVolumeCreationTest() {
+	By("Creating storage class", createStorageClass)
+}
+
+func cleanupAfterVolumeCreationTest() {
+	By("Deleting storage class", deleteStorageClass)
+}

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright © 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+
+	// auth plugins
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var (
+	openebsNamespace = "openebs"
+)
+
+func TestMtest(t *testing.T) {
+	//  if os.Getenv("E2ETEST") == "" {
+	//  t.Skip("Run under e2e/")
+	//}
+	rand.Seed(time.Now().UnixNano())
+
+	RegisterFailHandler(Fail)
+
+	SetDefaultEventuallyPollingInterval(time.Second)
+	SetDefaultEventuallyTimeout(time.Minute)
+
+	RunSpecs(t, "Test on sanity")
+}
+
+func waitKindnet() error {
+	stdout, stderr, err := Kubectl("-n=kube-system", "get", "ds/kindnet", "-o", "json")
+	if err != nil {
+		return errors.New(string(stderr))
+	}
+
+	var ds appsv1.DaemonSet
+	err = json.Unmarshal(stdout, &ds)
+	if err != nil {
+		return err
+	}
+
+	if ds.Status.NumberReady != 4 {
+		return fmt.Errorf("numberReady is not 4: %d", ds.Status.NumberReady)
+	}
+	return nil
+}
+
+var _ = BeforeSuite(func() {
+
+	var err error
+
+	By("creating storage class", createStorageClass)
+	By("creating namespace")
+	stdout, stderr, err := Kubectl("create", "ns", NSName)
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+})
+
+var _ = AfterSuite(func() {
+
+	By("creating storage class", deleteStorageClass)
+	By("deleting namespace")
+	stdout, stderr, err := Kubectl("delete", "ns", NSName)
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+})

--- a/tests/suite_test.go
+++ b/tests/suite_test.go
@@ -72,16 +72,17 @@ var _ = BeforeSuite(func() {
 
 	var err error
 
-	By("creating storage class", createStorageClass)
 	By("creating namespace")
 	stdout, stderr, err := Kubectl("create", "ns", NSName)
 	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+	By("Creating JivaVolumePolicy", createJivaVolumePolicy)
+
 })
 
 var _ = AfterSuite(func() {
 
-	By("creating storage class", deleteStorageClass)
-	By("deleting namespace")
+	By("Deleting JivaVolumePolicy", deleteJivaVolumePolicy)
+	By("Deleting namespace")
 	stdout, stderr, err := Kubectl("delete", "ns", NSName)
 	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
 })

--- a/tests/utils.go
+++ b/tests/utils.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+import (
+	"fmt"
+	"strings"
+
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func createStorageClass() {
+	By("creating above storageclass")
+	stdout, stderr, err := KubectlWithInput([]byte(SCYAML), "apply", "-f", "-")
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+}
+
+func deleteStorageClass() {
+	By("deleting storageclass")
+	stdout, stderr, err := KubectlWithInput([]byte(SCYAML), "delete", "-f", "-")
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+}
+
+func deletePVC() {
+	By("Deleting pvc")
+	stdout, stderr, err := KubectlWithInput([]byte(PVCYAML), "delete", "-n", NSName, "-f", "-")
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+
+	By("verifying pvc is deleted")
+	verifyPVCDeleted(NSName, PVCName)
+
+}
+
+func verifyPVCDeleted(ns, pvc string) {
+	var (
+		err error
+	)
+	maxRetries := 10
+	for i := 0; i < maxRetries; i++ {
+		_, _, err = Kubectl("get", "pvc", pvc, "-n", NSName)
+		if err == nil {
+			continue
+		}
+		break
+	}
+	Expect(err).NotTo(BeNil(), "not able to delete pvc")
+}
+
+func createAndVerifyPVC() {
+	var (
+		err error
+	)
+	By("creating pvc")
+	stdout, stderr, err := KubectlWithInput([]byte(PVCYAML), "apply", "-n", NSName, "-f", "-")
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+
+	By("verifying pv is bound")
+	verifyVolumeCreated(NSName, PVCName)
+}
+
+func verifyVolumeCreated(ns, pvc string) {
+	var volName string
+	maxRetries := 10
+	for i := 0; i < maxRetries; i++ {
+		stdout, stderr, err := Kubectl("get", "pvc", "-n", ns, pvc, "-o=template", "--template={{.spec.volumeName}}")
+		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+		volName = strings.TrimSpace(string(stdout))
+		if volName == "" {
+			fmt.Println("Waiting for PVC to have spec.VolumeName")
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		break
+	}
+	Expect(volName).NotTo(BeEmpty(), "not able to get pv name from PVC.Spec.VolumeName")
+}
+
+func createDeployVerifyApp() {
+	By("creating and deploying app pod", createAndDeployAppPod)
+	time.Sleep(30 * time.Second)
+	By("verifying app pod is running", verifyAppPodRunning)
+}
+
+func createAndDeployAppPod() {
+	var err error
+	By("building a busybox app pod deployment using above csi jiva volume")
+	stdout, stderr, err := KubectlWithInput([]byte(DeployYAML), "apply", "-n", NSName, "-f", "-")
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+}
+
+func deleteAppDeployment() {
+	By("deleting app deployment")
+	stdout, stderr, err := KubectlWithInput([]byte(DeployYAML), "delete", "-n", NSName, "-f", "-")
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+	By("verifying deployment is deleted")
+	maxRetries := 10
+	for i := 0; i < maxRetries; i++ {
+		_, _, err := Kubectl("get", "deploy", DeploymentName, "-n", NSName)
+		if err == nil {
+			continue
+		}
+		break
+	}
+	Expect(err).NotTo(BeNil(), "not able to delete deployment")
+}
+
+func verifyAppPodRunning() {
+	var (
+		state string
+	)
+	maxRetries := 10
+	for i := 0; i < maxRetries; i++ {
+		stdout, stderr, err := Kubectl("get", "po", "ubuntu", "-n", NSName, "-o=template", "--template={{.status.phase}}")
+		Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+		state = strings.TrimSpace(string(stdout))
+		if state != "Running" {
+			fmt.Println("Waiting for app pod to be in Running state")
+			time.Sleep(2 * time.Second)
+			continue
+		}
+		break
+	}
+
+	Expect(state).To(Equal("Running"), "while checking status of pod {%s}", "ubuntu")
+}
+
+func restartAppPodAndVerifyRunningStatus() {
+	By("deleting app pod")
+	stdout, stderr, err := Kubectl("delete", "po", "ubuntu", "-n", NSName)
+	Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", stdout, stderr)
+	By("verifying app pod has restarted")
+	verifyAppPodRunning()
+
+}

--- a/tests/yamls.go
+++ b/tests/yamls.go
@@ -1,0 +1,85 @@
+/*
+Copyright © 2020 The OpenEBS Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package volume
+
+var DeploymentName = "ubuntu"
+var DeployYAML = `
+apiVersion: apps/v1                                                                                                   
+kind: Deployment                                                                                          
+metadata:                                                                                                                                   
+  name: ubuntu                                                                                                                              
+  labels:                                                                                                                                   
+	app.kubernetes.io/name: ubuntu                                                                                                          
+spec:
+  selector:
+    matchLabels:
+	  name: ubuntu
+  replicas: 1
+  strategy:
+    type: Recreate
+    rollingUpdate: null
+  template:
+    metadata:
+	  labels:
+	    name: ubuntu
+	spec:
+      containers:
+      - name: ubuntu                                                                                                                                image: ubuntu                                                                                              
+	    command: ["/usr/local/bin/pause"]                       
+	    volumeMounts: 
+	    - mountPath: /test1                                                                                                                 
+	      name: my-volume
+      volumes:
+	  - name: my-volume
+	    persistentVolumeClaim:
+	      claimName: jiva-pvc                                                                                                         
+`
+
+var PVCName = "jiva-pvc"
+var PVCYAML = `
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: jiva-pvc
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+	requests:
+	  storage: %s
+  storageClassName: jiva-sc
+`
+
+var SCName = "jiva-sc"
+var SCYAML = `
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: openebs-jiva-csi-sc
+provisioner: jiva.csi.openebs.io
+parameters:
+  cas-type: "jiva"
+  policy: "example-jivavolumepolicy"
+`
+
+var NSName = "jiva-ns"
+var NSYAML = `
+kind: NameSpace
+apiVersion: v1
+metadata:
+  name: jiva-ns
+`

--- a/tests/yamls.go
+++ b/tests/yamls.go
@@ -23,30 +23,31 @@ kind: Deployment
 metadata:                                                                                                                                   
   name: ubuntu                                                                                                                              
   labels:                                                                                                                                   
-	app.kubernetes.io/name: ubuntu                                                                                                          
+    app.kubernetes.io/name: ubuntu
 spec:
   selector:
     matchLabels:
-	  name: ubuntu
+      name: ubuntu
   replicas: 1
   strategy:
     type: Recreate
     rollingUpdate: null
   template:
     metadata:
-	  labels:
-	    name: ubuntu
-	spec:
+      labels:
+        name: ubuntu
+    spec:
       containers:
-      - name: ubuntu                                                                                                                                image: ubuntu                                                                                              
-	    command: ["/usr/local/bin/pause"]                       
-	    volumeMounts: 
-	    - mountPath: /test1                                                                                                                 
-	      name: my-volume
+      - name: ubuntu
+        image: prateek14/ubuntu:18.04
+        command: ["/usr/local/bin/pause"]
+        volumeMounts:
+        - mountPath: /test1
+          name: my-volume
       volumes:
-	  - name: my-volume
-	    persistentVolumeClaim:
-	      claimName: jiva-pvc                                                                                                         
+      - name: my-volume
+        persistentVolumeClaim:
+          claimName: jiva-pvc
 `
 
 var PVCName = "jiva-pvc"
@@ -59,9 +60,9 @@ spec:
   accessModes:
   - ReadWriteOnce
   resources:
-	requests:
-	  storage: %s
-  storageClassName: jiva-sc
+    requests:
+      storage: 5G
+  storageClassName: jiva-csi-sc
 `
 
 var SCName = "jiva-sc"
@@ -69,7 +70,7 @@ var SCYAML = `
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: openebs-jiva-csi-sc
+  name: jiva-csi-sc
 provisioner: jiva.csi.openebs.io
 parameters:
   cas-type: "jiva"
@@ -82,4 +83,33 @@ kind: NameSpace
 apiVersion: v1
 metadata:
   name: jiva-ns
+`
+
+var policyYAML = `
+apiVersion: openebs.io/v1alpha1
+kind: JivaVolumePolicy
+metadata:
+  name: example-jivavolumepolicy
+  namespace: jiva-ns
+spec:
+  replicaSC: openebs-hostpath
+  enableBufio: false
+  autoScaling: false
+  target:
+    # monitor: false
+    replicationFactor: 1
+    # auxResources:
+    # tolerations:
+    # resources:
+    # affinity:
+    # nodeSelector:
+    # priorityClassName:
+  # replica:
+    # tolerations:
+    # resources:
+    # affinity:
+    # nodeSelector:
+    # priorityClassName:
+# status:
+  # phase:
 `

--- a/tests/yamls.go
+++ b/tests/yamls.go
@@ -90,7 +90,7 @@ apiVersion: openebs.io/v1alpha1
 kind: JivaVolumePolicy
 metadata:
   name: example-jivavolumepolicy
-  namespace: jiva-ns
+  namespace: openebs
 spec:
   replicaSC: openebs-hostpath
   enableBufio: false


### PR DESCRIPTION
This PR adds provisioning tests for jiva csi volumes.
```
STEP: creating namespace
STEP: Creating JivaVolumePolicy
[csi] [jiva] TEST VOLUME PROVISIONING WITH APP POD RESTART App is deployed and restarted on pvc with replica count 1 
  Should run Volume Creation Test
  /home/travis/gopath/src/github.com/openebs/jiva-csi/tests/provision_test.go:28
STEP: Creating storage class
STEP: creating and verifying PVC bound status
STEP: creating pvc
STEP: verifying pv is bound
STEP: Creating and deploying app pod
STEP: creating and deploying app pod
STEP: building a busybox app pod deployment using above csi jiva volume
STEP: verifying app pod is running
STEP: Restarting app pod and verifying app pod running status
STEP: deleting app pod
STEP: verifying app pod has restarted
STEP: Deleting application deployment
STEP: verifying deployment is deleted
STEP: Deleting pvc
STEP: verifying pvc is deleted
STEP: Deleting storage class
• [SLOW TEST:49.404 seconds]
[csi] [jiva] TEST VOLUME PROVISIONING WITH APP POD RESTART
/home/travis/gopath/src/github.com/openebs/jiva-csi/tests/provision_test.go:23
  App is deployed and restarted on pvc with replica count 1
  /home/travis/gopath/src/github.com/openebs/jiva-csi/tests/provision_test.go:27
    Should run Volume Creation Test
    /home/travis/gopath/src/github.com/openebs/jiva-csi/tests/provision_test.go:28
------------------------------
STEP: Deleting JivaVolumePolicy
STEP: Deleting namespace
```